### PR TITLE
Fixes on_windows() method when running under OSX and new DCERPC and SMB2 support

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -1078,7 +1078,7 @@ class TimeoutError(Exception):
   pass
 
 def on_windows():
-  return 'win' in system().lower()
+  return 'Win' in system()
 
 def ignore_ctrlc():
   if on_windows():


### PR DESCRIPTION
on_windows() checks platform.system().lower() == 'win'
However, under OSX the returned string is 'Darwin', matching 'win' ;)
According to https://docs.python.org/2/library/platform.html,
for Windows systems it should return 'Windows'.

I just changed the comparison against 'Win' w/o calling lower().
Hopefully it works well on all Windows.
It does work well on OSX :P