### PR TITLE
Always use Python2

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2012 Sebastien MACKE
 #


### PR DESCRIPTION
Use /usr/bin/env python2 since Patator doesn't work with Python 3.