### PR TITLE
Multiple conditions/actions fix

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -1492,19 +1492,19 @@ Please read the README inside for more examples and usage information.
     for action in actions.split(','):
 
       conds = [c.split('=', 1) for c in conditions.split(self.condition_delim)]
-
-      if '=' in action:
-        name, opts = action.split('=')
-      else:
-        name, opts = action, None
-
-      if name not in self.available_actions:
-        raise ValueError('Unsupported action: %s' % name)
-
-      if name not in ns_actions:
-        ns_actions[name] = []
-
-      ns_actions[name].append((conds, opts))
+      for cond in conds:
+        if '=' in action:
+          name, opts = action.split('=')
+        else:
+          name, opts = action, None
+  
+        if name not in self.available_actions:
+          raise ValueError('Unsupported action: %s' % name)
+  
+        if name not in ns_actions:
+          ns_actions[name] = []
+  
+        ns_actions[name].append(([cond], opts))
 
     self.ns.actions = ns_actions
 


### PR DESCRIPTION
Fix a mistake in update_actions when specifying multiple actions/conditions.

For instance, using "-x ignore,quit:code=123,code=456" there couldn't be any match on any of these 2 conditions. 
(However "-x ignore,quit:code=123 -x ignore,quit:code=456" worked though)
