### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ pip install impacket
 pip install paramiko
 pip install IPy
 pip install dnspython
+pip install pysnmp
 
 cd c:\
 git clone https://github.com/lanjelot/patator


### PR DESCRIPTION
A dep is missing 
Stack error msg 
```bash
python patator.py test
Traceback (most recent call last):
  File "patator.py", line 4332, in <module>
    from pysnmp.entity.rfc3413.oneliner import cmdgen
  File "/usr/local/lib/python2.7/dist-packages/pysnmp/entity/rfc3413/oneliner/cmdgen.py", line 10, in <module>
    from pysnmp.hlapi.asyncore import *
  File "/usr/local/lib/python2.7/dist-packages/pysnmp/hlapi/__init__.py", line 7, in <module>
    from pysnmp.proto.rfc1902 import *
  File "/usr/local/lib/python2.7/dist-packages/pysnmp/proto/rfc1902.py", line 563, in <module>
    class Bits(OctetString):
  File "/usr/local/lib/python2.7/dist-packages/pysnmp/proto/rfc1902.py", line 614, in Bits
    def __init__(self, value=univ.noValue, tagSet=None, subtypeSpec=None,
AttributeError: 'module' object has no attribute 'noValue'
```

missing dep pysnmp

