### PR TITLE
tcp_fuzz: Fix for error "'str' object has no attribute 'decode'"

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -4822,13 +4822,13 @@ class TCP_fuzz:
     fp = socket.create_connection((host, port), int(timeout))
     if ssl != '0':
       fp = wrap_socket(fp)
-    fp.send(data.decode('hex'))
+    fp.send(bytes(data,'utf-8'))
     with Timing() as timing:
       resp = fp.recv(1024)
     fp.close()
 
     code = 0
-    mesg = resp.encode('hex')
+    mesg = resp.decode('utf-8', errors='replace')
 
     return self.Response(code, mesg, timing)
 


### PR DESCRIPTION
I had the error "<class 'AttributeError'> 'str' object has no attribute 'decode'" and no result, when trying to use patator tcp_fuzz. The attached fix made it work, but I'm not an expert at all in python, so I am not sure this fix is correct. It seems to work at least for human-readable protocols, meaning when the exchanged data contains printable characters.
