### PR TITLE
Switched from pycrypto to pycryptodomex

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -4248,7 +4248,7 @@ class RDP_login:
 
 # VNC {{{
 try:
-  from Crypto.Cipher import DES
+  from Cryptodome.Cipher import DES
 except ImportError:
   notfound.append('pycrypto')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pyopenssl
 cx_Oracle
 mysqlclient
 psycopg2-binary
-pycrypto
+pycryptodomex
 dnspython
 IPy
 pysnmp


### PR DESCRIPTION
Hello @lanjelot,
Recently on Debian, the [pycrypto](https://bugs.debian.org/979318
) package was marked for removal, what do you think about replacing it with [pycryptodome](https://tracker.debian.org/pycryptodome) in your project?

The [patator](https://bugs.debian.org/971305) was marked for removal, but I applied this [patch](https://salsa.debian.org/pkg-security-team/patator/-/commit/b70b59b03fe20eed76b196d003300bed50ded26f) and apparently everything is fine.

Regards,
Francisco