### PR TITLE
Fix index out of range in COMBO, and unhexlify in tcp_fuzz

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -2062,7 +2062,7 @@ Please read the README inside for more examples and usage information.
             payload[k] = payload[k].replace('NET%d' % i, prod[i])
         elif t == 'COMBO':
           for j, k in keys:
-            payload[k] = payload[k].replace('COMBO%d%d' % (i, j), prod[i].split(self.combo_delim, len(keys)-1)[j])
+            payload[k] = payload[k].replace('COMBO%d%d' % (i, j), prod[i].split(self.combo_delim)[j])
         elif t == 'MOD':
           for k in keys:
             payload[k] = payload[k].replace('MOD%d' % i, prod[i])
@@ -5127,8 +5127,8 @@ class TCP_fuzz:
     fp = socket.create_connection((host, port), int(timeout))
     if ssl != '0':
       fp = wrap_socket(fp)
-    fp.send(unhexlify(data))
-    #fp.send(b(data))
+    #fp.send(unhexlify(data))
+    fp.send(b(data))
     with Timing() as timing:
       resp = fp.recv(1024)
     fp.close()


### PR DESCRIPTION
Fixes 'Index out of range' when using COMBO and not all the fields present in the input file.

given a file test.split that contains the following lines:
```
A:1:2:3:::
B:10:20:30:::
```

The commmand `patator.py dummy_test -t 1  data=COMBO00 data2='COMBO02:COMBO03' 0=test.split` will error with commit 5947f5f3919dd0ed1ccb0cf8d7b9996501d7a1e4 :
```
09:39:45 patator    INFO - Starting Patator 0.9 (https://github.com/lanjelot/patator) with python-3.8.5 at 2021-03-11 09:39 CET
09:39:45 patator    INFO -                                                                              
09:39:45 patator    INFO - code  size    time | candidate                          |   num | mesg
09:39:45 patator    INFO - -----------------------------------------------------------------------------
Process Consumer-0:
Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/didier/Tools/patator/patator.py", line 2065, in consume
    payload[k] = payload[k].replace('COMBO%d%d' % (i, j), prod[i].split(self.combo_delim, len(keys)-1)[j])
IndexError: list index out of range
09:39:46 patator    INFO - Hits/Done/Skip/Fail/Size: 0/0/0/0/2, Avg: 0 r/s, Time: 0h 0m 0s
09:39:46 patator    INFO - To resume execution, pass --resume 0
```
and gives the following output with this fix:
```
09:35:19 patator    INFO - Starting Patator 0.9 (https://github.com/lanjelot/patator) with python-3.8.5 at 2021-03-11 09:35 CET
09:35:19 patator    INFO -                                                                              
09:35:19 patator    INFO - code  size    time | candidate                          |   num | mesg
09:35:19 patator    INFO - -----------------------------------------------------------------------------
09:35:20 patator    INFO - 0     7      0.533 | A:1:2:3:::                         |     1 | A / 2:3
09:35:21 patator    INFO - 0     9      0.534 | B:10:20:30:::                      |     2 | B / 20:30
09:35:21 patator    INFO - Hits/Done/Skip/Fail/Size: 2/2/0/0/2, Avg: 1 r/s, Time: 0h 0m 1s
```