### PR TITLE
Update mysql connect() parameter

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -3535,7 +3535,7 @@ class MySQL_login:
 
     try:
       with Timing() as timing:
-        fp = _mysql.connect(host=host, port=int(port), user=user, passwd=password, connect_timeout=int(timeout))
+        fp = _mysql.connect(host=host, port=int(port), user=user, password=password, connect_timeout=int(timeout))
 
       resp = '0', fp.get_server_info()
 


### PR DESCRIPTION
Hello there, 

I really like patator and just ran into the issue when trying to bruteforce `mysql_logins`, that the following error occurred: 
```
<class 'TypeError'> 'passwd' is an invalid keyword argument for connect()
```

I checked the mysqlclient repo (stated in your dependency list) -> there it is written that `passwd` is deprecated (https://github.com/PyMySQL/mysqlclient/blob/main/MySQLdb/connections.py#L65).

However in this line https://github.com/PyMySQL/mysqlclient/blob/main/MySQLdb/connections.py#L154 they are still setting it. 

If I change the parameter in your script from `passwd` to `password` it works accordingly. 

I hope this helps - keep the work up. 

Cheerz,