### PR TITLE
Only set pycurl RESOLVE opt if resolve flag is set and not empty

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -3962,7 +3962,9 @@ class HTTP_fuzz(TCP_Cache):
     fp.setopt(pycurl.TIMEOUT, int(timeout))
     fp.setopt(pycurl.PROXY, proxy)
     fp.setopt(pycurl.PROXYTYPE, proxy_type)
-    fp.setopt(pycurl.RESOLVE, [resolve])
+
+    if resolve:
+      fp.setopt(pycurl.RESOLVE, [resolve])
 
     def noop(buf): pass
     fp.setopt(pycurl.WRITEFUNCTION, noop)


### PR DESCRIPTION
It seems that newer `pycurl` versions don't like when _RESOLVE_ is set empty.

Fixes #174 