### PR TITLE
Quiet Mode

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -932,7 +932,7 @@ def process_logs(queue, indicatorsfmt, argv, log_dir, runtime_file, csv_file, xm
       results += [('candidate', candidate), ('num', num), ('mesg', str(resp)), ('target', resp.str_target())]
 
       if typ == 'fail':
-        logger.warning(None, extra=dict(results))
+        logger.error(None, extra=dict(results))
       else:
         logger.info(None, extra=dict(results))
 


### PR DESCRIPTION
# Changes
- Non-critical-error output is moved from stderr to stdout 
	- `FAIL` actions were being logged at "Error" level, but do not halt patator execution, so they are also moved to stdout. 
	- Anything logged as `logging.CRITICAL` level will continue to go to stderr to make future development easier. 
- A new flag (`-q`) will suppress non-critical-error output. 
	- Only stdout is affected. All other forms of output are untouched.

# Rationale
This is partially in response to #60 and partially for my company's own use in automating use of Patator.   
The workaround suggested in the linked issue is to pipe stderr to `/dev/null` and use one of the other flags to write to an output file. This does solve the problem, but it also creates the issue of "hiding" critical errors.   
This change keeps errors visible and makes working with command-line output easier by writing to the dedicated stdout stream.