### PR TITLE
Fix base64 encoder

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -2074,7 +2074,7 @@ Please read the README inside for more examples and usage information.
             payload[k] = payload[k].replace('PROG%d' % i, prod[i])
 
       for k, m, e in self.enc_keys:
-        payload[k] = re.sub(r'{0}(.+?){0}'.format(m), lambda m: e(b(m.group(1))), payload[k])
+        payload[k] = re.sub(r'{0}(.+?){0}'.format(m), lambda m: e(b(m.group(1))).decode("utf8"), payload[k])
 
       logger.debug('product: %s' % prod)
       prod_str = ':'.join(prod)

--- a/patator.py
+++ b/patator.py
@@ -1420,7 +1420,7 @@ class Controller:
   available_encodings = {
     'hex': (lambda s: B(hexlify(s)), 'encode in hexadecimal'),
     'unhex': (lambda s: B(unhexlify(s)), 'decode from hexadecimal'),
-    'b64': (b64encode, 'encode in base64'),
+    'b64': (lambda s: b64encode(s).decode('utf8'), 'encode in base64'),
     'md5': (md5hex, 'hash in md5'),
     'sha1': (sha1hex, 'hash in sha1'),
     'url': (quote_plus, 'url encode'),
@@ -2074,7 +2074,7 @@ Please read the README inside for more examples and usage information.
             payload[k] = payload[k].replace('PROG%d' % i, prod[i])
 
       for k, m, e in self.enc_keys:
-        payload[k] = re.sub(r'{0}(.+?){0}'.format(m), lambda m: e(b(m.group(1))).decode("utf8"), payload[k])
+        payload[k] = re.sub(r'{0}(.+?){0}'.format(m), lambda m: e(b(m.group(1))), payload[k])
 
       logger.debug('product: %s' % prod)
       prod_str = ':'.join(prod)


### PR DESCRIPTION
Before:
```sh
$ echo -e "hello\ntest" > test.txt
$ python patator.py dummy_test data=_FILE0_ 0=test.txt -e _:b64
Process Consumer-1:
  File "/usr/lib64/python3.10/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib64/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/user/patator/patator.py", line 2077, in consume
    payload[k] = re.sub(r'{0}(.+?){0}'.format(m), lambda m: e(b(m.group(1))), payload[k])
  File "/usr/lib64/python3.10/re.py", line 209, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: sequence item 0: expected str instance, bytes found
```
After: 
```sh
$ python patator.py dummy_test data=_FILE0_ 0=test.txt -e _:b64
15:10:09 patator    INFO - Starting Patator 0.9 (https://github.com/lanjelot/patator) with python-3.10.4 at 2022-05-15 15:10 CEST
15:10:09 patator    INFO -
15:10:09 patator    INFO - code  size    time | candidate                          |   num | mesg
15:10:09 patator    INFO - -----------------------------------------------------------------------------
15:10:10 patator    INFO - 0     11     0.868 | test                               |     2 | dGVzdA== /
15:10:10 patator    INFO - 0     11     0.955 | hello                              |     1 | aGVsbG8= /
15:10:10 patator    INFO - Hits/Done/Skip/Fail/Size: 2/2/0/0/2, Avg: 1 r/s, Time: 0h 0m 1s
```
Tested on python 3.5 and 3.10