### PR TITLE
Write XML ending to correct file when using --xml

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -899,8 +899,8 @@ def process_logs(queue, indicatorsfmt, argv, log_dir, runtime_file, csv_file, xm
     pname, action, args = queue.get()
 
     if action == 'quit':
-      if log_dir:
-        with open(os.path.join(log_dir, 'RESULTS.xml'), 'a') as f:
+      if xml_file or log_dir:
+        with open(results_xml, 'a') as f:
           f.write('</results>\n<stop utc=%s local=%s/>\n</root>\n' % (xmlquoteattr(strfutctime()), xmlquoteattr(strflocaltime())))
       break
 


### PR DESCRIPTION
Previously when using `--xml=FILE` the beginning of the XML file would be written to `FILE`, while its ending would either (1) not be written at all (no `-l`/`-L` option), or (2) be written to RESULTS.xml in the directory specified using `-l`/`-L`. This patch ensures that the ending of the XML file is always written to the correct file.