### PR TITLE
fix: progress display is shown when it should not

### DIFF
--- a/patator.py
+++ b/patator.py
@@ -2234,7 +2234,7 @@ Please read the README inside for more examples and usage information.
 
       else:
         i, _, _ = select([sys.stdin], [], [], .1)
-        if not i:
+        if not i or not sys.stdin.isatty():
           return None
         command = i[0].readline().strip()
 


### PR DESCRIPTION
Patator spams status messages when the standard input is redirected, for instance when it runs in a bash loop. Below is a video capturing the issue. This fix disables the interactive features when the standard input is not a tty. Another solution would be to change the status command from "<Enter>" to some other letter.

The bug happens for example when running like this:
```bash
./patator.py ssh_login host=127.0.0.1 port=2222 user=user password=password </dev/null
```

https://github.com/lanjelot/patator/assets/23148601/6a085816-be6e-4fcc-812e-d68a12a3d0fa