### PR TITLE
Fix unzip problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN wget https://download.oracle.com/otn_software/linux/instantclient/instantcli
  && wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip \
  && unzip instantclient-basiclite-linuxx64.zip \
  && rm -f instantclient-basiclite-linuxx64.zip \
- && unzip instantclient-sdk-linuxx64.zip \
+ && unzip -n instantclient-sdk-linuxx64.zip \
  && rm -f instantclient-sdk-linuxx64.zip \
  && cd /opt/oracle/instantclient_* \
  && rm -f *jdbc* *occi* *mysql* *README *jar uidrvci genezi adrci \


### PR DESCRIPTION
Some files are similar on both zip files, this way there is a prompt to choose whether it must be extracted or not. Using `-n` unzip will not overwrite existing files without any prompt, so docker build will finally works.

Closes #227 

Build works without any problem:

```
~/.s/p/patator_docker> sudo docker build -t patator patator/                                                           08:58:02 [128/128]
[sudo] password for gildasio:
[+] Building 245.4s (17/17) FINISHED                                                                                      docker:default
 => [internal] load build definition from Dockerfile                                                                                0.0s
 => => transferring dockerfile: 3.32kB                                                                                              0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                     0.0s
 => [internal] load .dockerignore                                                                                                   0.0s
 => => transferring context: 2B                                                                                                     0.0s
 => [ 1/12] FROM docker.io/library/ubuntu:22.04                                                                                     0.0s
 => [internal] load build context                                                                                                   0.0s
 => => transferring context: 69B                                                                                                    0.0s
 => CACHED [ 2/12] RUN apt-get update  && apt-get install -y --no-install-recommends   build-essential python3-setuptools   libcur  0.0s
 => CACHED [ 3/12] RUN apt-get update  && apt-get install -y --no-install-recommends libaio1 wget unzip git  && rm -rf /var/lib/ap  0.0s
 => CACHED [ 4/12] WORKDIR /opt/oracle                                                                                              0.0s
 => [ 5/12] RUN wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linuxx64.zip  && wget ht  4.3s
 => [ 6/12] WORKDIR /opt/FreeRDP                                                                                                    0.1s
 => [ 7/12] RUN apt-get update  && apt-get install -y --no-install-recommends ninja-build build-essential git-core debhelper cdb  162.1s
 => [ 8/12] WORKDIR /opt/patator                                                                                                    0.1s
 => [ 9/12] COPY ./requirements.txt ./                                                                                              0.1s
 => [10/12] RUN python3 -m pip install --upgrade pip   && python3 -m pip install -r requirements.txt                               45.1s
 => [11/12] RUN apt-get update  && apt-get install -y --no-install-recommends ipython3 iputils-ping iproute2 netcat curl rsh-clie  30.6s
 => [12/12] COPY ./patator.py ./                                                                                                    0.1s
 => exporting to image                                                                                                              2.7s
 => => exporting layers                                                                                                             2.7s
 => => writing image sha256:3eb3ecd3bbf7de40c3e30de14a2de2717a4ca4bfb897686630990e0d88fddad7                                        0.0s
 => => naming to docker.io/library/patator                                                                                          0.0s
```

Also running in docker:

```
~/.s/p/patator_docker> sudo docker run -it --rm -v $PWD/SecLists/Passwords:/mnt patator dummy_test data=FILE0 0=/mnt/richelieu-french-top5000.txt
11:58:02 patator    INFO - Starting Patator 1.1-dev (https://github.com/lanjelot/patator) with python-3.10.12 at 2025-01-10 11:58 UTC
11:58:02 patator    INFO -
11:58:02 patator    INFO - code  size    time | candidate                          |   num | mesg
11:58:02 patator    INFO - -----------------------------------------------------------------------------
11:58:02 patator    INFO - 0     12     0.026 | 123456789                          |     2 | 123456789 /
11:58:02 patator    INFO - 0     9      0.337 | 123456                             |     1 | 123456 /
11:58:02 patator    INFO - 0     9      0.252 | qwerty                             |     5 | qwerty /
...
```